### PR TITLE
Add loop support

### DIFF
--- a/pomice/player.py
+++ b/pomice/player.py
@@ -61,6 +61,7 @@ class Player(VoiceProtocol):
         self._ending_track: Optional[Track] = None
 
         self._voice_state = {}
+        self._loop = False
 
     def __repr__(self):
         return (
@@ -305,6 +306,11 @@ class Player(VoiceProtocol):
         await self.seek(self.position)
         self._filter = filter
         return filter
+
+    async def set_loop(self, loop: bool) -> bool:
+        """Sets the loop state of the currently playing track""" # just kept set_pause doc string
+        self._loop = loop
+        return self._loop
 
     async def reset_filter(self):
         """Resets a currently applied filter to its default parameters.

--- a/pomice/player.py
+++ b/pomice/player.py
@@ -179,8 +179,11 @@ class Player(VoiceProtocol):
         event_type = data.get("type")
         event: PomiceEvent = getattr(events, event_type)(data, self)
 
-        if isinstance(event, TrackEndEvent) and event.reason != "REPLACED":
-            self._current = None
+        if isinstance(event, TrackEndEvent):
+            if self._loop:
+                await self.play(self._current)
+            elif event.reason != "REPLACED":
+                self._current = None
 
         event.dispatch(self._bot)
 
@@ -326,8 +329,3 @@ class Player(VoiceProtocol):
         await self._node.send(op="filters", guildId=str(self.guild.id), **_payload)
         await self.seek(self.position)
         self._filter = None
-
-
-
-        
-        


### PR DESCRIPTION
How it works:
With `set_loop` method we can set loop state.
Loop state is depends on `_loop` attribute and it is a bool object.
At the time of dispatching events, it checks if the event is TrackEndEvent and if loop is set to True, then it plays current track again.