### PR TITLE
Add Num-Shards header

### DIFF
--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -96,7 +96,8 @@ class Node:
         self._headers = {
             "Authorization": self._password,
             "User-Id": str(self._bot.user.id),
-            "Client-Name": f"Pomice/{__version__}"
+            "Client-Name": f"Pomice/{__version__}",
+            "Num-Shards": getattr(bot, "shards", 1)
         }
 
         self._players: Dict[int, Player] = {}

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -97,7 +97,7 @@ class Node:
             "Authorization": self._password,
             "User-Id": str(self._bot.user.id),
             "Client-Name": f"Pomice/{__version__}",
-            "Num-Shards": getattr(bot, "shards", 1)
+            "Num-Shards": str(getattr(bot, "shards", 1)),
         }
 
         self._players: Dict[int, Player] = {}


### PR DESCRIPTION
As noted [here](https://github.com/freyacodes/Lavalink/issues/319#issuecomment-650727169), `Num-Shards` header is necessary, but not implemented in the lib, this pr fixes that.

For me, this fixed the `Cannot write to closing transport` error.