### PR TITLE
Update VoiceProtocol for latest discord.py change

### DIFF
--- a/pomice/player.py
+++ b/pomice/player.py
@@ -205,8 +205,8 @@ class Player(VoiceProtocol):
         """
         return await self._node.get_tracks(query, ctx=ctx, search_type=search_type)
 
-    async def connect(self, *, timeout: float, reconnect: bool):
-        await self.guild.change_voice_state(channel=self.channel)
+    async def connect(self, *, timeout: float, reconnect: bool, self_deaf: bool = False, self_mute: bool = False):
+        await self.guild.change_voice_state(channel=self.channel, self_deaf=self_deaf, self_mute=self_mute)
         self._node._players[self.guild.id] = self
         self._is_connected = True
 


### PR DESCRIPTION
There was a breaking change a few days ago involving VoiceProtocol in the master branch of discord.py, you can see more information about it here https://github.com/Rapptz/discord.py/pull/7886.

This patch should be backwards compatible with v1.7 due to the usage of default arguments while simultaneously being forward compatible with the v2 breaking change.