### PR TITLE
feat: allow custom logging handler; fix: missing typings

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ pre-commit = "*"
 furo = "*"
 sphinx = "*"
 myst-parser = "*"
+black = "*"
+typing-extensions = "*"
 
 [requires]
 python_version = "3.8"

--- a/docs/hdi/pool.md
+++ b/docs/hdi/pool.md
@@ -70,6 +70,10 @@ After you have initialized your function, we need to fill in the proper paramete
   - `LogLevel`
   - The logging level for the node. The default logging level is `LogLevel.INFO`.
 
+* - `log_handler`
+  - `Optional[logging.Handler]`
+  - The logging handler for the node. Set to `None` to disable the default logging handler.
+
 :::
 
 

--- a/pomice/player.py
+++ b/pomice/player.py
@@ -132,7 +132,11 @@ class Player(VoiceProtocol):
     )
 
     def __call__(self, client: Client, channel: VoiceChannel) -> Player:
-        return self.__class__(client, channel)
+        self.client = client
+        self.channel = channel
+        self._guild = channel.guild
+
+        return self
 
     def __init__(
         self,

--- a/pomice/player.py
+++ b/pomice/player.py
@@ -131,12 +131,8 @@ class Player(VoiceProtocol):
         "_player_endpoint_uri",
     )
 
-    def __call__(self, client: Client, channel: VoiceChannel):
-        self.client: Client = client
-        self.channel: VoiceChannel = channel
-        self._guild: Guild = channel.guild
-
-        return self
+    def __call__(self, client: Client, channel: VoiceChannel) -> Player:
+        return self.__class__(client, channel)
 
     def __init__(
         self,
@@ -262,7 +258,7 @@ class Player(VoiceProtocol):
         """
         return self.guild.id not in self._node._players
 
-    def _adjust_end_time(self):
+    def _adjust_end_time(self) -> Optional[str]:
         if self._node._version >= LavalinkVersion(3, 7, 5):
             return None
 

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -217,6 +217,7 @@ class Node:
     def _setup_logging(self, level: LogLevel) -> logging.Logger:
         logger = logging.getLogger("pomice")
         logger.setLevel(level)
+        handler = None
 
         if self._log_handler is not None:
             handler = self._log_handler
@@ -230,6 +231,8 @@ class Node:
                 style="{",
             )
             handler.setFormatter(formatter)
+
+        if handler:
             logger.addHandler(handler)
 
         return logger

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -233,6 +233,7 @@ class Node:
             handler.setFormatter(formatter)
 
         if handler:
+            logger.handlers.clear()
             logger.addHandler(handler)
 
         return logger


### PR DESCRIPTION
# Changes done

- Added ability to specify `log_handler` (identical behaviour with discord.py)
- Added missing typing hints
- Defaulted lavalink ver to 0.0.0 instead of None which will fail if attempting comparisons
- Updated documentation to reflect changes
- Changed version checking to use regex (correctly parses versions such as `3`, `3.5`, `3.7.5`, `3.5-rc3_Unknown`, `3.7.5-SNAPSHOT`, `3text`)

(note: it is not necessary to specify types in `__call__` as they are already defined in `__init__`, this causes a redefined types error with mypy)