### PR TITLE
`spotify_client_id` data type correction

### DIFF
--- a/docs/hdi/player.md
+++ b/docs/hdi/player.md
@@ -365,7 +365,7 @@ await Player.stop()
 
 To move the player to another channel, we need to use `Player.move_to()`
 
-```py 
+```py
 
 await Player.move_to(...)
 

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -159,7 +159,7 @@ class Node:
 
         self._players: Dict[int, Player] = {}
 
-        self._spotify_client_id: Optional[int] = spotify_client_id
+        self._spotify_client_id: Optional[str] = spotify_client_id
         self._spotify_client_secret: Optional[str] = spotify_client_secret
 
         self._apple_music_client: Optional[applemusic.Client] = None

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -109,7 +109,7 @@ class Node:
         heartbeat: int = 30,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         session: Optional[aiohttp.ClientSession] = None,
-        spotify_client_id: Optional[int] = None,
+        spotify_client_id: Optional[str] = None,
         spotify_client_secret: Optional[str] = None,
         apple_music: bool = False,
         fallback: bool = False,


### PR DESCRIPTION
Spotify client ids contain chars therefore cannot be integers, entering string data will not cause errors but it has to change to avoid confusion.