### PR TITLE
Fix AttributeError when Spotify client ID not provided to Node

### DIFF
--- a/pomice/__init__.py
+++ b/pomice/__init__.py
@@ -20,7 +20,7 @@ if not discord.version_info.major >= 2:
         "using 'pip install discord.py'",
     )
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __title__ = "pomice"
 __author__ = "cloudwithax"
 __license__ = "GPL-3.0"

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -159,6 +159,7 @@ class Node:
 
         self._players: Dict[int, Player] = {}
 
+        self._spotify_client: Optional[spotify.Client] = None
         self._spotify_client_id: Optional[str] = spotify_client_id
         self._spotify_client_secret: Optional[str] = spotify_client_secret
 
@@ -169,8 +170,6 @@ class Node:
                 self._spotify_client_id,
                 self._spotify_client_secret,
             )
-        else:
-            self._spotify_client = None
 
         if apple_music:
             self._apple_music_client = applemusic.Client()

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -169,6 +169,8 @@ class Node:
                 self._spotify_client_id,
                 self._spotify_client_secret,
             )
+        else:
+            self._spotify_client = None
 
         if apple_music:
             self._apple_music_client = applemusic.Client()


### PR DESCRIPTION
This PR fixes an AttributeError that is raised when a Node is initialized without Spotify client ID and/or secret. The issue results in the `connect` method failing meaning that Pomice won't connect to Lavalink unless the client ID and secret are specified.

This is raised in the latest version of the library due to the `if self._spotify_client:` on line 278 of [pool.py](https://github.com/cloudwithax/pomice/blob/56843c459c94dd250e6dc69a6acecc3d9bbae9fb/pomice/pool.py#L278) since _spotify_client can be undefined. This sets it to None if the values are not provided to avoid this issue.