### PR TITLE
Account for Lavalink v4 changes when loading YT playlists

### DIFF
--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -837,7 +837,7 @@ class Node:
             )
 
         elif load_type in ("SEARCH_RESULT", "TRACK_LOADED", "track", "search"):
-            if self._version.major >= 4 and isinstance(data[data_type],dict):
+            if self._version.major >= 4 and isinstance(data[data_type], dict):
                 data[data_type] = [data[data_type]]
             return [
                 Track(

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -813,6 +813,12 @@ class Node:
             return None
 
         elif load_type in ("PLAYLIST_LOADED", "playlist"):
+            if self._version.major >= 4:
+                track_list = data[data_type]["tracks"]
+                playlist_info = data[data_type]["info"]
+            else:
+                track_list = data[data_type]
+                playlist_info = data["playlistInfo"]
             tracks = [
                 Track(
                     track_id=track["encoded"],
@@ -820,10 +826,10 @@ class Node:
                     ctx=ctx,
                     track_type=TrackType(track["info"]["sourceName"]),
                 )
-                for track in data[data_type]
+                for track in track_list
             ]
             return Playlist(
-                playlist_info=data["playlistInfo"],
+                playlist_info=playlist_info,
                 tracks=tracks,
                 playlist_type=PlaylistType(tracks[0].track_type.value),
                 thumbnail=tracks[0].thumbnail,

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -837,6 +837,8 @@ class Node:
             )
 
         elif load_type in ("SEARCH_RESULT", "TRACK_LOADED", "track", "search"):
+            if self._version.major >= 4 and isinstance(data[data_type],dict):
+                data[data_type] = [data[data_type]]
             return [
                 Track(
                     track_id=track["encoded"],


### PR DESCRIPTION
It seems Lavalink v4 returns YT playlist data differently than v3.  This should account for both v3 and v4 approaches.

-CorpNewt

***

Looks like there were issues when passing a YT URL as well - so I've pushed another commit to resolve that.  It's not as elegant as I'd like as it just wraps the `data[data_type]` in a list (if using v4 and `data[data_type]` is a dictionary) in order to work with the current list comprehension, but it appears to function on both v3 and v4.