### PR TITLE
chore: remove `reorder-python-imports`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,37 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
-    -   id: check-ast
-    -   id: check-builtin-literals
-    -   id: debug-statements
-    -   id: end-of-file-fixer
-    -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 23.10.1
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
     hooks:
-    - id: black
-      language_version: python3.11
--   repo: https://github.com/asottile/pyupgrade
+      - id: black
+        language_version: python3.11
+  - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]
--   repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-    -   id: reorder-python-imports
--   repo: https://github.com/asottile/add-trailing-comma
+      - id: isort
+  - repo: https://github.com/asottile/add-trailing-comma
     rev: v3.1.0
     hooks:
-    -   id: add-trailing-comma
--   repo: https://github.com/hadialqattan/pycln
-    rev: v2.3.0
+      - id: add-trailing-comma
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v2.4.0
     hooks:
-    -   id: pycln
+      - id: pycln
 
 default_language_version:
-    python: python3.11
+  python: python3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
@@ -17,3 +14,7 @@ no_implicit_optional = true
 check_untyped_defs = true
 warn_unused_ignores = true
 show_error_codes = true
+
+[tool.isort]
+force_single_line = true
+profile = "black"


### PR DESCRIPTION
Resolves #60 

Replaced `reorder-python-imports` with `isort` which is compatible with black.