### PR TITLE
fix: remove unnecessary assert

### DIFF
--- a/pomice/events.py
+++ b/pomice/events.py
@@ -128,7 +128,6 @@ class TrackExceptionEvent(PomiceEvent):
 
     def __init__(self, data: dict, player: Player):
         self.player: Player = player
-        assert self.player._ending_track is not None
         self.track: Optional[Track] = self.player._ending_track
         # Error is for Lavalink <= 3.3
         self.exception: str = data.get(


### PR DESCRIPTION
Hit this in production (https://sunnycord.sentry.io/share/issue/e39efaaa16d64b4fbf4e3ec409406971/) 
The assert is unnecessary since track is typed as optional either way.