### PR TITLE
feat: use pydantic for model validation

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,9 @@ name = "pypi"
 
 [packages]
 orjson = "*"
+pydantic = ">=2"
 "discord.py" = {extras = ["voice"], version = "*"}
+websockets = "*"
 
 [dev-packages]
 mypy = "*"

--- a/pomice/models/__init__.py
+++ b/pomice/models/__init__.py
@@ -1,0 +1,6 @@
+import pydantic
+from pydantic import ConfigDict
+
+
+class BaseModel(pydantic.BaseModel):
+    model_config = ConfigDict(populate_by_name=True)

--- a/pomice/models/version.py
+++ b/pomice/models/version.py
@@ -1,0 +1,27 @@
+from typing import NamedTuple
+
+
+class LavalinkVersion(NamedTuple):
+    major: int
+    minor: int
+    fix: int
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, LavalinkVersion):
+            return False
+
+        return (
+            (self.major == other.major) and (self.minor == other.minor) and (self.fix == other.fix)
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, LavalinkVersion):
+            return False
+
+        if self.major > other.major:
+            return False
+        if self.minor > other.minor:
+            return False
+        if self.fix > other.fix:
+            return False
+        return True

--- a/pomice/player.py
+++ b/pomice/player.py
@@ -30,7 +30,7 @@ from .objects import Playlist
 from .objects import Track
 from .pool import Node
 from .pool import NodePool
-from pomice.utils import LavalinkVersion
+from pomice.models.version import LavalinkVersion
 
 if TYPE_CHECKING:
     from discord.types.voice import VoiceServerUpdate

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -20,16 +20,13 @@ import aiohttp
 import orjson as json
 from discord import Client
 from discord.ext import commands
-from discord.utils import MISSING
 from websockets import client
 from websockets import exceptions
-from websockets import typing as wstype
 
 from . import __version__
 from . import applemusic
 from . import spotify
 from .enums import *
-from .enums import LogLevel
 from .exceptions import InvalidSpotifyClientAuthorization
 from .exceptions import LavalinkVersionIncompatible
 from .exceptions import NodeConnectionFailure
@@ -43,9 +40,9 @@ from .objects import Playlist
 from .objects import Track
 from .routeplanner import RoutePlanner
 from .utils import ExponentialBackoff
-from .utils import LavalinkVersion
 from .utils import NodeStats
 from .utils import Ping
+from pomice.models.version import LavalinkVersion
 
 if TYPE_CHECKING:
     from .player import Player

--- a/pomice/utils.py
+++ b/pomice/utils.py
@@ -8,7 +8,6 @@ from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
-from typing import NamedTuple
 from typing import Optional
 
 from .enums import RouteIPType
@@ -20,7 +19,6 @@ __all__ = (
     "FailingIPBlock",
     "RouteStats",
     "Ping",
-    "LavalinkVersion",
 )
 
 
@@ -226,53 +224,3 @@ class Ping:
         s_runtime = 1000 * (cost_time)
 
         return s_runtime
-
-
-class LavalinkVersion(NamedTuple):
-    major: int
-    minor: int
-    fix: int
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        return (
-            (self.major == other.major) and (self.minor == other.minor) and (self.fix == other.fix)
-        )
-
-    def __ne__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        return not (self == other)
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        if self.major > other.major:
-            return False
-        if self.minor > other.minor:
-            return False
-        if self.fix > other.fix:
-            return False
-        return True
-
-    def __gt__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        return not (self < other)
-
-    def __le__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        return (self < other) or (self == other)
-
-    def __ge__(self, other: object) -> bool:
-        if not isinstance(other, LavalinkVersion):
-            return False
-
-        return (self > other) or (self == other)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 import setuptools
 
 version = ""
-requirements = ["aiohttp>=3.7.4,<4", "orjson", "websockets"]
+requirements = ["aiohttp>=3.7.4,<4", "orjson", "websockets", "pydantic>=2"]
 with open("pomice/__init__.py") as f:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',


### PR DESCRIPTION
## Description

[Pydantic](https://docs.pydantic.dev/latest/) is the industry standard tool for model validation. It is a well trusted tool baked into other libraries (such as FastAPI).

This PR aims to shift the library into using it. It will be a very big one, but I will attempt to keep commit history simple.

## Reasoning

- It would be a massive gain towards stability and type safety
- It would provide very simple ways of handling versioned models using [smart unions](https://docs.pydantic.dev/latest/concepts/unions/#smart-mode) meaning we could remove a large portion of `if` statements for lavalink versions
- It would remove a massive amount of boilerplate we have to write
- Pydantic is ""blazing fast"" as the rust devs would say it

## To-do:

#### Models:
- [x] LavalinkVersion
- [ ] Track

#### Code Style:
- [ ] Remove relative imports (this will be followed by a second PR to change the library to use poetry instead of pipenv, something which we arguably should have done in the first place as DX with pipenv for libraries simply sucks)