### PR TITLE
Fix KeyError in exception handling on error when loading a track.

### DIFF
--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -733,7 +733,7 @@ class Node:
             )
 
         elif load_type in ("LOAD_FAILED", "error"):
-            exception = data['data'] if self._version.major >= 4 else data["exception"]
+            exception = data["data"] if self._version.major >= 4 else data["exception"]
             raise TrackLoadError(
                 f"{exception['message']} [{exception['severity']}]",
             )

--- a/pomice/pool.py
+++ b/pomice/pool.py
@@ -733,7 +733,7 @@ class Node:
             )
 
         elif load_type in ("LOAD_FAILED", "error"):
-            exception = data["exception"]
+            exception = data['data'] if self._version.major >= 4 else data["exception"]
             raise TrackLoadError(
                 f"{exception['message']} [{exception['severity']}]",
             )


### PR DESCRIPTION
This fixes a `KeyError` caused by formatting inconsistencies between Lavalink v4 and previous versions.

When Lavalink fails to load a track (e.g. Spotify is disabled, but providing a Spotify URL which is sent to Lavalink, resulting in an error), a KeyError is thrown because Lavalink v4 changed the formatting for exceptions.