### PR TITLE
Fix Support for Other Source and Playlist Types

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 orjson = "*"
 "discord.py" = {extras = ["voice"], version = "*"}
+websockets = "*"
 
 [dev-packages]
 mypy = "*"

--- a/pomice/enums.py
+++ b/pomice/enums.py
@@ -65,7 +65,7 @@ class TrackType(Enum):
     APPLE_MUSIC = "apple_music"
     HTTP = "http"
     LOCAL = "local"
-    OTHER = 'other'
+    OTHER = "other"
 
     @classmethod
     def _missing_(cls, value):

--- a/pomice/enums.py
+++ b/pomice/enums.py
@@ -54,6 +54,8 @@ class TrackType(Enum):
     TrackType.HTTP defines that the track is from an HTTP source.
 
     TrackType.LOCAL defines that the track is from a local source.
+
+    TrackType.OTHER defines that the track is from an unknown source (possible from 3rd-party plugins).
     """
 
     # We don't have to define anything special for these, since these just serve as flags
@@ -63,6 +65,11 @@ class TrackType(Enum):
     APPLE_MUSIC = "apple_music"
     HTTP = "http"
     LOCAL = "local"
+    OTHER = 'other'
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.OTHER
 
     def __str__(self) -> str:
         return self.value

--- a/pomice/enums.py
+++ b/pomice/enums.py
@@ -68,7 +68,7 @@ class TrackType(Enum):
     OTHER = "other"
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, _: object) -> "TrackType":
         return cls.OTHER
 
     def __str__(self) -> str:

--- a/pomice/enums.py
+++ b/pomice/enums.py
@@ -98,7 +98,7 @@ class PlaylistType(Enum):
     OTHER = "other"
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, _: object) -> "PlaylistType":
         return cls.OTHER
 
     def __str__(self) -> str:

--- a/pomice/enums.py
+++ b/pomice/enums.py
@@ -86,6 +86,8 @@ class PlaylistType(Enum):
     PlaylistType.SPOTIFY defines that the playlist is from Spotify
 
     PlaylistType.APPLE_MUSIC defines that the playlist is from Apple Music.
+
+    PlaylistType.OTHER defines that the playlist is from an unknown source (possible from 3rd-party plugins).
     """
 
     # We don't have to define anything special for these, since these just serve as flags
@@ -93,6 +95,11 @@ class PlaylistType(Enum):
     SOUNDCLOUD = "soundcloud"
     SPOTIFY = "spotify"
     APPLE_MUSIC = "apple_music"
+    OTHER = "other"
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.OTHER
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
Given Lavalink's support for track types beyond the hard-coded ones as well as the more recent adoption of plugins like LavaSrc to add more sources, this update adds support for a generic `OTHER` type on both `enums.TrackType` and `enums.PlaylistType`.

When an unsupported value is found, it will default it to the `OTHER` type, meaning that it maintains the existing enum structure, providing support for more specialized functionality, while also allowing for a catch-all with the caveat that behaviour is largely undefined from the library's standpoint.

Additionally, I added websockets as a dependency to the Pipfile since it was missing.